### PR TITLE
Rework loading API

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,2 @@
-v.2.1.2
-- will wipe map dimensions on boot to fix many bugs and incompatibilities..
-REPORT ANY PROBLEMS QUICKLY, bugs from this feature can be nasty but it's a needed feature
+v.2.2.0
+- (internal) Revise data loading API

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
 # --- COMMON GRADLE START ---
 # Mod Properties
-mod_version=2.1.4
+mod_version=2.2.0
 
 #Parchment
 parchment_minecraft=1.20.1

--- a/src/main/java/com/robertx22/library_of_exile/components/LibChunkCap.java
+++ b/src/main/java/com/robertx22/library_of_exile/components/LibChunkCap.java
@@ -57,7 +57,7 @@ public class LibChunkCap implements ICap {
     @Override
     public void deserializeNBT(CompoundTag nbt) {
         try {
-            this.mapGenData = LoadSave.loadOrBlank(MapChunkData.class, new MapChunkData(), nbt, "map", new MapChunkData());
+            this.mapGenData = LoadSave.loadOrBlank(MapChunkData.class, nbt, "map", MapChunkData::new);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/robertx22/library_of_exile/components/LibMapCap.java
+++ b/src/main/java/com/robertx22/library_of_exile/components/LibMapCap.java
@@ -84,7 +84,7 @@ public class LibMapCap implements ICapabilityProvider, INBTSerializable<Compound
     public void deserializeNBT(CompoundTag nbt) {
 
         try {
-            this.data = LoadSave.loadOrBlank(LibMapDataSaver.class, new LibMapDataSaver(), nbt, "data", new LibMapDataSaver());
+            this.data = LoadSave.loadOrBlank(LibMapDataSaver.class, nbt, "data", LibMapDataSaver::new);
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/robertx22/library_of_exile/components/MapConnectionsCap.java
+++ b/src/main/java/com/robertx22/library_of_exile/components/MapConnectionsCap.java
@@ -65,7 +65,7 @@ public class MapConnectionsCap implements ICapabilityProvider, INBTSerializable<
 
         try {
 
-            this.data = LoadSave.loadOrBlank(AllMapConnectionData.class, new AllMapConnectionData(), nbt, "data", new AllMapConnectionData());
+            this.data = LoadSave.loadOrBlank(AllMapConnectionData.class, nbt, "data", AllMapConnectionData::new);
 
 
         } catch (JsonSyntaxException e) {

--- a/src/main/java/com/robertx22/library_of_exile/utils/LoadSave.java
+++ b/src/main/java/com/robertx22/library_of_exile/utils/LoadSave.java
@@ -5,6 +5,8 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import net.minecraft.nbt.CompoundTag;
 
+import java.util.function.Supplier;
+
 
 public class LoadSave {
 
@@ -33,8 +35,7 @@ public class LoadSave {
 
     }
 
-    public static <OBJ extends Object> OBJ Load(Class theclass, OBJ newobj, CompoundTag nbt, String loc) {
-
+    public static <OBJ> OBJ load(Class<OBJ> clazz, CompoundTag nbt, String loc) {
         OBJ o = null;
         if (nbt == null) {
             return null;
@@ -47,27 +48,42 @@ public class LoadSave {
         }
 
         try {
-            o = (OBJ) gson.fromJson(json, theclass);
+            o = gson.fromJson(json, clazz);
         } catch (JsonSyntaxException e) {
             e.printStackTrace();
         }
 
         return o;
-
     }
 
-    public static <OBJ> OBJ loadOrBlank(Class theclass, OBJ newobj, CompoundTag nbt, String loc, OBJ blank) {
+    /**
+     * @deprecated Replaced with {@link LoadSave#load(Class, CompoundTag, String)}
+     */
+    @Deprecated(since = "2.2.0", forRemoval = true)
+    public static <OBJ> OBJ Load(Class clazz, OBJ newobj, CompoundTag nbt, String loc) {
+        return load((Class<OBJ>) clazz, nbt, loc);
+    }
+
+    public static <OBJ> OBJ loadOrBlank(Class<OBJ> clazz, CompoundTag nbt, String loc, Supplier<OBJ> blank) {
         try {
-            OBJ data = Load(theclass, newobj, nbt, loc);
+            OBJ data = load(clazz, nbt, loc);
             if (data == null) {
-                return blank;
+                return blank.get();
             } else {
                 return data;
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
-        return blank;
+        return blank.get();
+    }
+
+    /**
+     * @deprecated Replaced with {@link  LoadSave#loadOrBlank(Class, CompoundTag, String, Supplier)}
+     */
+    @Deprecated(since = "2.2.0", forRemoval = true)
+    public static <OBJ> OBJ loadOrBlank(Class clazz, OBJ newobj, CompoundTag nbt, String loc, OBJ blank) {
+        return loadOrBlank((Class<OBJ>) clazz, nbt, loc, () -> blank);
     }
 
 }


### PR DESCRIPTION
This adds two methods to `LoadSave` to replace the old `Load` and `loadOrBlank` methods:

```java
// Take `Class<OBJ>` for class instead of raw `Class`
// Remove unused `newobj` parameter

public static <OBJ> OBJ load(Class<OBJ> clazz, CompoundTag nbt, String loc);
// Take `Supplier<OBJ>` for `blank` to avoid creating a new object unless needed
public static <OBJ> OBJ loadOrBlank(Class<OBJ> clazz, CompoundTag nbt, String loc, Supplier<OBJ> blank);
```

Unlike in #3, the old methods are only deprecated to avoid causing immediate API breakage.