### PR TITLE
Generify registration

### DIFF
--- a/src/main/java/com/robertx22/library_of_exile/database/init/LibDatabase.java
+++ b/src/main/java/com/robertx22/library_of_exile/database/init/LibDatabase.java
@@ -25,23 +25,23 @@ import net.minecraft.data.CachedOutput;
 public class LibDatabase extends ExileDatabaseInit {
     public static LibDatabase INSTANCE = new LibDatabase(Ref.MODID);
 
-    public static ExileRegistryType MAP_DATA_BLOCK = ExileRegistryType.register(Ref.MODID, "map_data_block", 0, MapDataBlock.SERIALIZER, SyncTime.NEVER);
-    public static ExileRegistryType MOB_LIST = ExileRegistryType.register(Ref.MODID, "mob_list", 0, MobList.SERIALIZER, SyncTime.NEVER);
-    public static ExileRegistryType MOB_AFFIX = ExileRegistryType.register(Ref.MODID, "mob_affix", 0, ExileMobAffix.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType MAP_FINISH_RARITY = ExileRegistryType.register(Ref.MODID, "map_finish_rar", 0, MapFinishRarity.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType MAP_CONTENT = ExileRegistryType.register(Ref.MODID, "map_content", 0, MapContent.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType LEAGUE = ExileRegistryType.register(Ref.MODID, "league", 0, null, SyncTime.NEVER);
+    public static ExileRegistryType<MapDataBlock> MAP_DATA_BLOCK = ExileRegistryType.register(Ref.MODID, "map_data_block", 0, MapDataBlock.SERIALIZER, SyncTime.NEVER);
+    public static ExileRegistryType<MobList> MOB_LIST = ExileRegistryType.register(Ref.MODID, "mob_list", 0, MobList.SERIALIZER, SyncTime.NEVER);
+    public static ExileRegistryType<ExileMobAffix> MOB_AFFIX = ExileRegistryType.register(Ref.MODID, "mob_affix", 0, ExileMobAffix.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<MapFinishRarity> MAP_FINISH_RARITY = ExileRegistryType.register(Ref.MODID, "map_finish_rar", 0, MapFinishRarity.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<MapContent> MAP_CONTENT = ExileRegistryType.register(Ref.MODID, "map_content", 0, MapContent.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<League> LEAGUE = ExileRegistryType.register(Ref.MODID, "league", 0, null, SyncTime.NEVER);
 
     // Atlas
-    public static ExileRegistryType RELIC_STAT = ExileRegistryType.register(Ref.MODID, "relic_stat", 0, RelicStat.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType RELIC_TYPE = ExileRegistryType.register(Ref.MODID, "relic_type", 1, RelicType.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType RELIC_AFFIX = ExileRegistryType.register(Ref.MODID, "relic_affix", 2, RelicAffix.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType RELIC_RARITY = ExileRegistryType.register(Ref.MODID, "relic_rarity", 3, RelicRarity.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<RelicStat> RELIC_STAT = ExileRegistryType.register(Ref.MODID, "relic_stat", 0, RelicStat.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<RelicType> RELIC_TYPE = ExileRegistryType.register(Ref.MODID, "relic_type", 1, RelicType.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<RelicAffix> RELIC_AFFIX = ExileRegistryType.register(Ref.MODID, "relic_affix", 2, RelicAffix.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<RelicRarity> RELIC_RARITY = ExileRegistryType.register(Ref.MODID, "relic_rarity", 3, RelicRarity.SERIALIZER, SyncTime.ON_LOGIN);
 
-    public static ExileRegistryType ITEM_MOD = ExileRegistryType.register(Ref.MODID, "item_modification", 48, ItemModification.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType ITEM_REQ = ExileRegistryType.register(Ref.MODID, "item_requirement", 49, ItemRequirement.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType CURRENCY = ExileRegistryType.register(Ref.MODID, "currency", 50, ExileCurrency.SERIALIZER, SyncTime.ON_LOGIN);
-    public static ExileRegistryType ORB_EDIT = ExileRegistryType.register(Ref.MODID, "orb_edit", 51, OrbEdit.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<ItemModification> ITEM_MOD = ExileRegistryType.register(Ref.MODID, "item_modification", 48, ItemModification.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<ItemRequirement> ITEM_REQ = ExileRegistryType.register(Ref.MODID, "item_requirement", 49, ItemRequirement.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<ExileCurrency> CURRENCY = ExileRegistryType.register(Ref.MODID, "currency", 50, ExileCurrency.SERIALIZER, SyncTime.ON_LOGIN);
+    public static ExileRegistryType<OrbEdit> ORB_EDIT = ExileRegistryType.register(Ref.MODID, "orb_edit", 51, OrbEdit.SERIALIZER, SyncTime.ON_LOGIN);
 
     public LibDatabase(String modid) {
         super(modid);
@@ -66,21 +66,21 @@ public class LibDatabase extends ExileDatabaseInit {
     @Override
     public void initDatabases() {
 
-        Database.addRegistry(new ExileRegistryContainer<>(MAP_DATA_BLOCK, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(MOB_LIST, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(MOB_AFFIX, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(MAP_FINISH_RARITY, "common"));
-        Database.addRegistry(new ExileRegistryContainer<>(MAP_CONTENT, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(LEAGUE, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(RELIC_STAT, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(RELIC_TYPE, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(RELIC_AFFIX, "empty"));
-        Database.addRegistry(new ExileRegistryContainer<>(RELIC_RARITY, "common"));
+        Database.addRegistry(new ExileRegistryContainer<MapDataBlock>(MAP_DATA_BLOCK, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<MobList>(MOB_LIST, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<ExileMobAffix>(MOB_AFFIX, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<MapFinishRarity>(MAP_FINISH_RARITY, "common"));
+        Database.addRegistry(new ExileRegistryContainer<MapContent>(MAP_CONTENT, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<League>(LEAGUE, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<RelicStat>(RELIC_STAT, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<RelicType>(RELIC_TYPE, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<RelicAffix>(RELIC_AFFIX, "empty"));
+        Database.addRegistry(new ExileRegistryContainer<RelicRarity>(RELIC_RARITY, "common"));
 
-        Database.addRegistry(new ExileRegistryContainer<>(LibDatabase.ITEM_MOD, ""));
-        Database.addRegistry(new ExileRegistryContainer<>(LibDatabase.ITEM_REQ, ""));
-        Database.addRegistry(new ExileRegistryContainer<>(LibDatabase.ORB_EDIT, ""));
-        Database.addRegistry(new ExileRegistryContainer<>(LibDatabase.CURRENCY, "socket_adder"));
+        Database.addRegistry(new ExileRegistryContainer<ItemModification>(LibDatabase.ITEM_MOD, ""));
+        Database.addRegistry(new ExileRegistryContainer<ItemRequirement>(LibDatabase.ITEM_REQ, ""));
+        Database.addRegistry(new ExileRegistryContainer<OrbEdit>(LibDatabase.ORB_EDIT, ""));
+        Database.addRegistry(new ExileRegistryContainer<ExileCurrency>(LibDatabase.CURRENCY, "socket_adder"));
 
 
     }

--- a/src/main/java/com/robertx22/library_of_exile/main/MyPacket.java
+++ b/src/main/java/com/robertx22/library_of_exile/main/MyPacket.java
@@ -20,7 +20,7 @@ public abstract class MyPacket<T> {
 
     public abstract MyPacket<T> newInstance();
 
-    public final MyPacket loadFromDataUSETHIS(FriendlyByteBuf buf) {
+    public final MyPacket<T> loadFromDataUSETHIS(FriendlyByteBuf buf) {
 
         MyPacket<T> data = newInstance();
         try {

--- a/src/main/java/com/robertx22/library_of_exile/packets/registry/EfficientRegistryPacket.java
+++ b/src/main/java/com/robertx22/library_of_exile/packets/registry/EfficientRegistryPacket.java
@@ -18,19 +18,19 @@ import net.minecraft.resources.ResourceLocation;
 
 import java.util.List;
 
-public class EfficientRegistryPacket<T extends ISerializable & JsonExileRegistry> extends MyPacket<EfficientRegistryPacket> {
+public class EfficientRegistryPacket<T extends ISerializable<T> & JsonExileRegistry<T>> extends MyPacket<EfficientRegistryPacket<T>> {
     public static final JsonParser PARSER = new JsonParser();
 
     public static ResourceLocation ID = new ResourceLocation(Ref.MODID, "eff_reg");
     private List<T> items;
 
-    ExileRegistryType type;
+    ExileRegistryType<T> type;
 
     public EfficientRegistryPacket() {
 
     }
 
-    public EfficientRegistryPacket(ExileRegistryType type, List<T> list) {
+    public EfficientRegistryPacket(ExileRegistryType<T> type, List<T> list) {
         this.type = type;
         this.items = list;
     }
@@ -43,9 +43,11 @@ public class EfficientRegistryPacket<T extends ISerializable & JsonExileRegistry
     @Override
     public void loadFromData(FriendlyByteBuf buf) {
 
-        this.type = ExileRegistryType.get(buf.readUtf());
+        var type = ExileRegistryType.get(buf.readUtf());
+        // TODO: try to remove this cast
+        this.type = (ExileRegistryType<T>) type;
 
-        ISerializable<T> serializer = type.getSerializer();
+        ISerializable<T> serializer = this.type.getSerializer();
 
         this.items = Lists.newArrayList();
 
@@ -72,7 +74,7 @@ public class EfficientRegistryPacket<T extends ISerializable & JsonExileRegistry
     @Override
     public void onReceived(ExilePacketContext ctx) {
 
-        ExileRegistryContainer reg = Database.getRegistry(type);
+        ExileRegistryContainer<T> reg = Database.getRegistry(type);
 
         items.forEach(x -> {
             x.unregisterFromExileRegistry();
@@ -84,7 +86,7 @@ public class EfficientRegistryPacket<T extends ISerializable & JsonExileRegistry
     }
 
     @Override
-    public MyPacket<EfficientRegistryPacket> newInstance() {
-        return new EfficientRegistryPacket();
+    public MyPacket<EfficientRegistryPacket<T>> newInstance() {
+        return new EfficientRegistryPacket<>();
     }
 }

--- a/src/main/java/com/robertx22/library_of_exile/registry/Database.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/Database.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class Database {
 
-    private static HashMap<ExileRegistryType, ExileRegistryContainer> SERVER = new HashMap<>();
+    private static HashMap<ExileRegistryType<?>, ExileRegistryContainer<?>> SERVER = new HashMap<>();
     //  private static HashMap<ExileRegistryType, ExileRegistryContainer> BACKUP = new HashMap<>();
 
     public static boolean areDatapacksLoaded(Level world) {
@@ -21,22 +21,22 @@ public class Database {
     }
 
 
-    public static List<ExileRegistryContainer> getAllRegistries() {
+    public static List<ExileRegistryContainer<?>> getAllRegistries() {
         return new ArrayList<>(SERVER.values());
     }
 
-    public static ExileRegistryContainer getRegistry(ExileRegistryType type) {
-        return SERVER.get(type);
+    public static <T extends ExileRegistry<T>> ExileRegistryContainer<T> getRegistry(ExileRegistryType<T> type) {
+        return (ExileRegistryContainer<T>) SERVER.get(type);
     }
 
-    public static ExileRegistry get(ExileRegistryType type, String guid) {
+    public static <T extends ExileRegistry<T>> ExileRegistry<T> get(ExileRegistryType<T> type, String guid) {
         return getRegistry(type).get(guid);
 
     }
 
     public static void sendPacketsToClient(ServerPlayer player, SyncTime sync) {
 
-        List<ExileRegistryType> list = ExileRegistryType.getInRegisterOrder(sync);
+        List<ExileRegistryType<?>> list = ExileRegistryType.getInRegisterOrder(sync);
 
         list.forEach(x -> getRegistry(x).sendUpdatePacket(player));
     }
@@ -79,7 +79,7 @@ public class Database {
 
     }
 
-    public static void addRegistry(ExileRegistryContainer cont) {
+    public static <C extends ExileRegistry<C>> void addRegistry(ExileRegistryContainer<C> cont) {
         SERVER.put(cont.getType(), cont);
     }
 }

--- a/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistry.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistry.java
@@ -4,13 +4,22 @@ import com.google.gson.JsonObject;
 import com.robertx22.library_of_exile.registry.register_info.ExileRegistrationInfo;
 import com.robertx22.library_of_exile.registry.register_info.RegistrationInfoData;
 
-public interface ExileRegistry<C> extends IGUID, IWeighted {
+/**
+ * Denotes a class whose instances can be registered by Library of Exile.
+ * <p>
+ * Note that this does not actually contain the registry data;
+ * this is done in {@link ExileRegistryContainer}.
+ *
+ * @param <C> the same class that implements this interface
+ */
+public interface ExileRegistry<C extends ExileRegistry<C>> extends IGUID, IWeighted {
 
-    ExileRegistryType getExileRegistryType();
+    ExileRegistryType<C> getExileRegistryType();
 
 
     default void registerToExileRegistry(ExileRegistrationInfo info) {
-        Database.getRegistry(getExileRegistryType()).register(this, info);
+        // TODO: try to remove need for this cast
+        Database.getRegistry(getExileRegistryType()).register((C) this, info);
     }
 
     default RegistrationInfoData getRegistrationInfo() {

--- a/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistryContainer.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistryContainer.java
@@ -17,7 +17,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class ExileRegistryContainer<C extends ExileRegistry> {
+public class ExileRegistryContainer<C extends ExileRegistry<C>> {
 
     private List<String> registersErrorsAlertedFor = new ArrayList<>();
     private List<String> accessorErrosAletedFor = new ArrayList<>();
@@ -85,7 +85,7 @@ public class ExileRegistryContainer<C extends ExileRegistry> {
         return fromDatapacks;
     }
 
-    public ExileRegistryType getType() {
+    public ExileRegistryType<C> getType() {
         return type;
     }
 
@@ -98,7 +98,7 @@ public class ExileRegistryContainer<C extends ExileRegistry> {
 
     }
 
-    private ExileRegistryType type;
+    private ExileRegistryType<C> type;
     private String emptyDefault;
 
     public C getDefault() {
@@ -110,23 +110,21 @@ public class ExileRegistryContainer<C extends ExileRegistry> {
     private boolean logAdditionsToRegistry = false;
     private boolean logMissingEntryOnAccess = true;
 
-    public ExileRegistryContainer logAdditions() {
+    public ExileRegistryContainer<C> logAdditions() {
         this.logAdditionsToRegistry = true;
         return this;
     }
 
-    public void unRegister(ExileRegistry entry) {
-        if (map.containsKey(entry.GUID())) {
-            map.remove(entry.GUID());
-        }
+    public void unRegister(ExileRegistry<C> entry) {
+        map.remove(entry.GUID());
     }
 
-    public ExileRegistryContainer dontErrorMissingEntriesOnAccess() {
+    public ExileRegistryContainer<C> dontErrorMissingEntriesOnAccess() {
         this.logMissingEntryOnAccess = false;
         return this;
     }
 
-    public ExileRegistryContainer dontErrorIfEmpty() {
+    public ExileRegistryContainer<C> dontErrorIfEmpty() {
         this.errorIfEmpty = false;
         return this;
     }
@@ -139,7 +137,7 @@ public class ExileRegistryContainer<C extends ExileRegistry> {
         return getSize() > 0;
     }
 
-    public ExileRegistryContainer(ExileRegistryType type, String emptyDefault) {
+    public ExileRegistryContainer(ExileRegistryType<C> type, String emptyDefault) {
         this.type = type;
         this.emptyDefault = emptyDefault;
     }

--- a/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistryType.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/ExileRegistryType.java
@@ -10,23 +10,22 @@ import net.minecraftforge.fml.ModList;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class ExileRegistryType {
+public class ExileRegistryType<T extends ExileRegistry<T>> {
 
-    private static HashMap<String, ExileRegistryType> map = new HashMap<>();
+    private static final HashMap<String, ExileRegistryType<?>> map = new HashMap<>();
 
     public String id;
-    ISerializable ser;
+    ISerializable<T> ser;
     int order;
     public SyncTime syncTime;
     public String modid;
     // used for lang file tc
     public String idWithoutModid;
 
-    public ExileRegistryType(String modid, String id, int order, ISerializable ser, SyncTime synctime) {
+    public ExileRegistryType(String modid, String id, int order, ISerializable<T> ser, SyncTime synctime) {
 
         Preconditions.checkNotNull(modid);
         Preconditions.checkNotNull(id);
-        Preconditions.checkNotNull(order);
         Preconditions.checkNotNull(synctime);
 
         this.modid = modid;
@@ -41,11 +40,11 @@ public class ExileRegistryType {
         return ModList.get().getModContainerById(modid).get().getModInfo().getDisplayName();
     }
 
-    public static ExileRegistryType get(String id) {
+    public static ExileRegistryType<?> get(String id) {
         return map.get(id);
     }
 
-    public static ExileRegistryType register(ExileRegistryType type) {
+    public static <C extends ExileRegistry<C>> ExileRegistryType<C> register(ExileRegistryType<C> type) {
         Preconditions.checkNotNull(type);
 
         if (map.containsKey(type.id)) {
@@ -56,24 +55,23 @@ public class ExileRegistryType {
         return type;
     }
 
-    public static ExileRegistryType register(String modid, String id, int order, ISerializable ser, SyncTime synctime) {
-        ExileRegistryType type = new ExileRegistryType(modid, id, order, ser, synctime);
+    public static <C extends ExileRegistry<C>> ExileRegistryType<C> register(String modid, String id, int order, ISerializable<C> ser, SyncTime synctime) {
+        ExileRegistryType<C> type = new ExileRegistryType<>(modid, id, order, ser, synctime);
         return register(type);
     }
 
-    public static List<ExileRegistryType> getInRegisterOrder(SyncTime sync) {
-        List<ExileRegistryType> list = map.values().stream()
+    public static List<ExileRegistryType<?>> getInRegisterOrder(SyncTime sync) {
+        return map.values().stream()
                 .filter(x -> x.syncTime == sync)
+                .sorted(Comparator.comparingInt(x -> x.order))
                 .collect(Collectors.toList());
-        list.sort(Comparator.comparingInt(x -> x.order));
-        return list;
 
     }
 
-    public static List<ExileRegistryType> getAllInRegisterOrder() {
-        List<ExileRegistryType> list = new ArrayList<>();
+    public static List<ExileRegistryType<?>> getAllInRegisterOrder() {
+        List<ExileRegistryType<?>> list = new ArrayList<>();
 
-        for (Map.Entry<String, ExileRegistryType> en : map.entrySet()) {
+        for (Map.Entry<String, ExileRegistryType<?>> en : map.entrySet()) {
             if (en.getValue() == null) {
                 throw new RuntimeException(en.getKey() + " is a null registry type, how?!");
             } else {
@@ -88,7 +86,7 @@ public class ExileRegistryType {
 
 
     public static void registerJsonListeners(AddReloadListenerEvent manager) {
-        List<ExileRegistryType> list = getAllInRegisterOrder();
+        List<ExileRegistryType<?>> list = getAllInRegisterOrder();
         list.forEach(x -> {
             if (x.getLoader() != null) {
                 manager.addListener(x.getLoader());
@@ -114,7 +112,7 @@ public class ExileRegistryType {
                 .getSerializable();
     }
 
-    public final ISerializable getSerializer() {
+    public final ISerializable<T> getSerializer() {
         return ser;
     }
 

--- a/src/main/java/com/robertx22/library_of_exile/registry/FilterListWrap.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/FilterListWrap.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class FilterListWrap<C extends ExileRegistry> {
+public class FilterListWrap<C extends ExileRegistry<C>> {
 
     public FilterListWrap(List<C> list) {
         this.list = list;

--- a/src/main/java/com/robertx22/library_of_exile/registry/JsonExileRegistry.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/JsonExileRegistry.java
@@ -13,10 +13,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-public interface JsonExileRegistry<T> extends ExileRegistry<T> {
+public interface JsonExileRegistry<T extends ExileRegistry<T>> extends ExileRegistry<T> {
 
     default void addToSerializables(ExileRegistrationInfo info) {
-        Database.getRegistry(getExileRegistryType()).addSerializable(this, info);
+        // TOOD: try to remove need for this cast
+        Database.getRegistry(getExileRegistryType()).addSerializable((T) this, info);
     }
 
 

--- a/src/main/java/com/robertx22/library_of_exile/registry/loaders/BaseDataPackLoader.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/loaders/BaseDataPackLoader.java
@@ -15,18 +15,18 @@ import net.minecraft.util.profiling.ProfilerFiller;
 
 import java.util.*;
 
-public class BaseDataPackLoader<T extends ExileRegistry> extends SimpleJsonResourceReloadListener {
-    private static Gson GSON = IAutoGson.createGson();
+public class BaseDataPackLoader<T extends ExileRegistry<T>> extends SimpleJsonResourceReloadListener {
+    private static final Gson GSON = IAutoGson.createGson();
 
 
     public String id;
     ISerializable<T> serializer;
-    public ExileRegistryType registryType;
+    public ExileRegistryType<T> registryType;
 
 
-    public static HashMap<ExileRegistryType, List<String>> INFO_MAP = new HashMap<>();
+    public static HashMap<ExileRegistryType<?>, List<String>> INFO_MAP = new HashMap<>();
 
-    public BaseDataPackLoader(ExileRegistryType registryType, String id, ISerializable<T> serializer) {
+    public BaseDataPackLoader(ExileRegistryType<T> registryType, String id, ISerializable<T> serializer) {
         super(GSON, id);
         Objects.requireNonNull(registryType);
         this.id = id;
@@ -57,7 +57,7 @@ public class BaseDataPackLoader<T extends ExileRegistry> extends SimpleJsonResou
     protected void apply(Map<ResourceLocation, JsonElement> mapToLoad, ResourceManager manager, ProfilerFiller profilerIn) {
 
         try {
-            ExileRegistryContainer reg = Database.getRegistry(registryType);
+            ExileRegistryContainer<T> reg = Database.getRegistry(registryType);
 
             Watch normal = new Watch();
             normal.min = 50000;

--- a/src/main/java/com/robertx22/library_of_exile/registry/serialization/ISerializable.java
+++ b/src/main/java/com/robertx22/library_of_exile/registry/serialization/ISerializable.java
@@ -29,14 +29,12 @@ public interface ISerializable<T> {
     default JsonObject getDefaultJson() {
         JsonObject json = new JsonObject();
 
-        if (this instanceof IGUID) {
-            IGUID claz = (IGUID) this;
-            json.addProperty(ID, claz.GUID());
+        if (this instanceof IGUID self) {
+            json.addProperty(ID, self.GUID());
         }
 
-        if (this instanceof IWeighted) {
-            IWeighted claz = (IWeighted) this;
-            json.addProperty(WEIGHT, claz.Weight());
+        if (this instanceof IWeighted self) {
+            json.addProperty(WEIGHT, self.Weight());
         }
 
         return json;

--- a/src/main/java/com/robertx22/library_of_exile/util/iTiered.java
+++ b/src/main/java/com/robertx22/library_of_exile/util/iTiered.java
@@ -6,7 +6,7 @@ import com.robertx22.library_of_exile.registry.ExileRegistryContainer;
 
 import java.util.Optional;
 
-public interface iTiered<T extends ExileRegistry & iTiered<T>> {
+public interface iTiered<T extends ExileRegistry<T> & iTiered<T>> {
 
     public int getTier();
 


### PR DESCRIPTION
This PR makes `ExileRegistryType` generic with respect to the type of object being registered and changes code to use generic types more consistently to reduce the number of unchecked casts in the codebase. I wished to avoid breaking API, but this is a lot harder to do than with #4, and some things in the Mine and Slash code are broken anyway, so…

**Must be applied concurrently with mahjerion/Mine-and-Slash-Rework#51**